### PR TITLE
git: fix resolved exec_path

### DIFF
--- a/lib/git-secure-tag.js
+++ b/lib/git-secure-tag.js
@@ -1,7 +1,12 @@
 'use strict';
 
-const GIT = process.env.GIT_SSH_COMMAND || process.env.GIT_SSH ||
-            process.env.GIT_EXEC_PATH || 'git';
+const path = require('path');
+
+let GIT = process.env.GIT_SSH_COMMAND || process.env.GIT_SSH || 'git';
+
+if (process.env.GIT_EXEC_PATH) {
+  GIT = path.join(process.env.GIT_EXEC_PATH, 'git');
+}
 
 exports.GIT = GIT;
 exports.common = require('./git-secure-tag/common');


### PR DESCRIPTION
$GIT_EXEC_PATH will return a path to where the `git` binary exists
and as such needs to have the binary path manually appended.

Fixes: #3